### PR TITLE
Use bumpversion for version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 0.4.5
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:nodefinder_gui/nodefinder_gui.py]
+


### PR DESCRIPTION
Use [bumpversion](https://github.com/peritus/bumpversion) to bump version (commit and tag automatically).
