### PR TITLE
Fix display insert point for width 20 bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ Next Release
 
 Will be released in the near future...
 
+Version v0.4.6
+--------------
+
+Bugfix:
+- Fix display insertion point for 20 char width bug
+
 Version v0.4.5
 --------------
 

--- a/nodefinder_gui/nodefinder_gui.py
+++ b/nodefinder_gui/nodefinder_gui.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 from subprocess import Popen, PIPE
+
 if sys.version[0] == '2':
     import Tkinter as tk
     import ttk
@@ -26,7 +27,6 @@ elif sys.version[0] == '3':
     import tkinter.scrolledtext as st
 else:
     raise ImportError('Cannot identify your Python version.')
-
 
 __version__ = '0.4.5'
 __author__ = 'Jin'
@@ -98,17 +98,16 @@ Documentation of %s (Ver. %s)
 
 # Use set(list()) for Python2.6 compatibility
 NONE_TREE_NAME_SYMBOL_SET = set(
-        [',', ';', ')', '"', "'", '#', '$', '@', '>', '<'])
+    [',', ';', ')', '"', "'", '#', '$', '@', '>', '<'])
 NO_CALI_EXISTS_SYMBOL_SET = set([',', ';', ')'])
 WITH_CALI_EXISTS_SYMBOL_SET = set(
-        ['>', '<', '@', '0', '1', "'", '"', '$', ':'])
+    ['>', '<', '@', '0', '1', "'", '"', '$', ':'])
 NO_LABEL_EXISTS_SYMBOL_SET = set([',', ';', ')'])
 WITH_LABEL_EXISTS_SYMBOL_SET = set(
-        ['>', '<', '@', '0', '1', "'", '"', '$', ':', '#'])
+    ['>', '<', '@', '0', '1', "'", '"', '$', ':', '#'])
 WARNING_CALI_OR_LABEL_INFO_SYMBOL_SET = set(
-        ['>', '<', '@', '#', '$', "'", '"', ':'])
+    ['>', '<', '@', '#', '$', "'", '"', ':'])
 WARNING_BRANCH_LABEL_SYMBOL_SET = set(['@', '#', '$', "'", ':'])
-
 
 global_insertion_list_cache = {}
 
@@ -135,6 +134,7 @@ class RightClickMenu(object):
     If you prefer to import Tkinter over Tix, just replace all Tix
     references with Tkinter and this will still work fine.
     """
+
     def __init__(self, parent):
         self.parent = parent
         # bind Control-A to select_all() to the widget.  All other
@@ -223,6 +223,7 @@ class RightClickMenu(object):
 
 class RightClickMenuForScrolledText(object):
     """Simple widget to add basic right click menus to entry widgets."""
+
     def __init__(self, parent):
         self.parent = parent
         # bind Control-A to select_all() to the widget.  All other
@@ -286,7 +287,7 @@ class RightClickMenuForScrolledText(object):
     def _paste_if_string_in_clipboard(self):
         self.parent.event_generate("<<Paste>>")
 
-    def _select_all(self,):
+    def _select_all(self, ):
         """select all"""
         self.parent.tag_add('sel', "1.0", "end-1c")
         self.parent.mark_set('insert', "1.0")
@@ -315,6 +316,7 @@ class RightClickMenuForScrolledText(object):
 
 class TextEmit(object):
     """Redirect stdout and stderr to tk widgets."""
+
     def __init__(self, widget, tag='stdout'):
         """Initialize widget which stdout and stderr were redirected to."""
         self.widget = widget
@@ -337,6 +339,7 @@ class App(tk.Frame):
         >>> app = App()
         >>> app.mainloop()
     """
+
     def __init__(self, master=None):
         tk.Frame.__init__(self, master)
         # Setting title.
@@ -366,30 +369,30 @@ class App(tk.Frame):
         s.configure(
             'execute.TButton',
             foreground='red',
-            )
+        )
         s.configure(
             'newline.TButton',
             padding=6),
         s.configure(
             'clear.TButton',
             foreground='#2AA198',
-            )
+        )
 
         # Configure Combobox style
         s.configure('TCombobox', padding=6)
-        s.configure('config.TCombobox',)
+        s.configure('config.TCombobox', )
 
         # Configure Title Frame
         s.configure(
             'title.TLabel',
             padding=10,
             font=('helvetica', 11, 'bold'),
-            )
+        )
         s.configure(
             'config.TLabel',
             padding=1,
             font=('arial', 9),
-            )
+        )
 
     def create_widgets(self):
         """Create widgets in the main window.
@@ -435,18 +438,18 @@ class App(tk.Frame):
             self.tree_pane,
             text='Origin Tree',
             style='title.TLabel',
-            )
+        )
 
         self.open_tree_file_button = ttk.Button(
             self.tree_pane,
             text='Open Tree File...',
-            )
+        )
 
         self.clear_tree_input = ttk.Button(
             self.tree_pane,
             text='Clear',
             style='clear.TButton',
-            )
+        )
 
         self.tree_name = tk.StringVar()
         self.choose_tree_box = ttk.Combobox(self.tree_pane,
@@ -455,7 +458,7 @@ class App(tk.Frame):
         self.load_history_button = ttk.Button(
             self.tree_pane,
             text='Load History',
-            )
+        )
 
         self.tree_paste_area = st.ScrolledText(
             self.tree_pane)
@@ -480,13 +483,13 @@ class App(tk.Frame):
             self.config_pane,
             text='Execute All',
             style='execute.TButton',
-            )
+        )
 
         self.clear_config_area_button = ttk.Button(
             self.config_pane,
             text='Clear',
             style='clear.TButton',
-            )
+        )
 
         self.read_config_file_button = ttk.Button(
             self.config_pane,
@@ -511,7 +514,7 @@ class App(tk.Frame):
             self.config_pane,
             text='Add New',
             style='newline.TButton',
-            )
+        )
 
         self.name_a_combobox = ttk.Combobox(
             self.config_pane, style='config.TCombobox')
@@ -523,7 +526,7 @@ class App(tk.Frame):
             self.config_pane, style='config.TCombobox')
 
         self.config_lines_area = st.ScrolledText(
-            self.config_pane,)
+            self.config_pane, )
 
         # +-------------------+-------------------+
         # |                   |                   |
@@ -542,29 +545,29 @@ class App(tk.Frame):
             self.out_tree_pane,
             text='Tree Output',
             style='title.TLabel',
-            )
+        )
 
         self.view_as_ascii_button = ttk.Button(
             self.out_tree_pane,
             text='View As ASCII'
-            )
+        )
 
         self.save_current_dir_button = ttk.Button(
             self.out_tree_pane,
             text='Quick Save',
-            )
+        )
 
         self.save_as_button = ttk.Button(
             self.out_tree_pane,
             text='Save New Tree As...',
-            )
+        )
 
         # Clear out tree button
         self.clear_out_tree_button = ttk.Button(
             self.out_tree_pane,
             text='Clear',
             style='clear.TButton',
-            )
+        )
         self.clear_out_tree_button.grid(row=0, column=4, sticky='we')
 
         # Out Tree area
@@ -591,21 +594,21 @@ class App(tk.Frame):
         self.save_log_button = ttk.Button(
             self.log_pane,
             text='Save Log As...',
-            )
+        )
 
         # Clear out tree button
         self.clear_log_button = ttk.Button(
             self.log_pane,
             text='Clear',
             style='clear.TButton',
-            )
+        )
 
         self.log_area = st.ScrolledText(
             self.log_pane,
             fg='#FDF6E3',
             bg='#002B36',
             state='disabled',
-            )
+        )
 
     def configure_grid(self):
         self.master.grid()
@@ -739,7 +742,7 @@ class App(tk.Frame):
 
         # Right click menu for config input area
         right_menu_config = RightClickMenuForScrolledText(
-                self.config_lines_area)
+            self.config_lines_area)
         self.config_lines_area.bind('<Button-3>', right_menu_config)
 
         # Right click menu for output area
@@ -810,8 +813,8 @@ class App(tk.Frame):
             edit_menu.add_command(label="Paste", command=self._paste)
         else:
             edit_menu.add_command(
-                    label='Paste',
-                    command=lambda: print('No string in clipboard!'))
+                label='Paste',
+                command=lambda: print('No string in clipboard!'))
         edit_menu.add_command(label="Delete", command=self._delete)
         menu_bar.add_cascade(label="Edit", menu=edit_menu)
 
@@ -951,8 +954,8 @@ class App(tk.Frame):
 
     def _set_value_to_textarea(self):
         """Value to textarea."""
-        name_a, name_b, info = self.name_a_combobox.get(),\
-            self.name_b_combobox.get(), self.info_combobox.get()
+        name_a, name_b, info = self.name_a_combobox.get(), \
+                               self.name_b_combobox.get(), self.info_combobox.get()
         config_list = filter(lambda x: x != '', [name_a, name_b, info])
         if len(config_list) < 2 or not info:
             sys.stderr.write('[ ERROR | %s ]\n[Usage]\n' % time_now())
@@ -1113,11 +1116,11 @@ def get_index_of_tmrca(clean_tree_str, name_a, name_b):
     insertion_list_b = get_insertion_list(clean_tree_str, name_b)
     # print(insertion_list_a)
     # print(insertion_list_b)
-    insertion_list_a, insertion_list_b = insertion_list_a[::-1],\
-        insertion_list_b[::-1]
-    shorter_list = insertion_list_a if len(insertion_list_a) <\
-        len(insertion_list_b) else insertion_list_b
-    longer_list = insertion_list_a if shorter_list == insertion_list_b else\
+    insertion_list_a, insertion_list_b = insertion_list_a[::-1], \
+                                         insertion_list_b[::-1]
+    shorter_list = insertion_list_a if len(insertion_list_a) < \
+                                       len(insertion_list_b) else insertion_list_b
+    longer_list = insertion_list_a if shorter_list == insertion_list_b else \
         insertion_list_b
     # print('[Shorter List]: ', shorter_list)
     # print('[Longer List]:  ', longer_list)
@@ -1127,10 +1130,30 @@ def get_index_of_tmrca(clean_tree_str, name_a, name_b):
         if shorter_list[i] != longer_list[i]:
             cali_point = shorter_list[i - 1]
             break
-    print('[Common]:  ', cali_point)
-    print('\n[Insert]:  ', clean_tree_str[cali_point-20:cali_point+20])
-    print('[Insert]:  ', '                 ->||<-                  ')
-    print('[Insert]:  ', '               Insert Here               ')
+
+    tree_len = len(clean_tree_str)
+    print('[Common]:   %s\n' % cali_point)
+    if cali_point < 20 <= tree_len - cali_point:
+        print('[Insert]:   %s%s' % (
+            ' ' * (20 - cali_point),
+            clean_tree_str[:cali_point + 20])
+        )
+    elif cali_point >= 20 > tree_len - cali_point:
+        print('[Insert]:   %s' % (
+            clean_tree_str[
+                cali_point- 20:cali_point + (tree_len - cali_point)])
+        )
+    elif cali_point < 20 and tree_len - cali_point < 20:
+        print('[Insert]:   %s%s' % (
+            ' ' * (20 - cali_point),
+            clean_tree_str[:cali_point + (tree_len - cali_point)])
+        )
+    else:
+        print('[Insert]:   %s' % (
+            clean_tree_str[cali_point - 20:cali_point + 20])
+        )
+    print('[Insert]:                    ->||<-                 ')
+    print('[Insert]:                  Insert Here              ')
 
     return cali_point
 
@@ -1152,8 +1175,8 @@ def single_calibration(tree_str, name_a, name_b, cali_info):
 
     # No calibration before
     if clean_tree_str[cali_point] in NO_CALI_EXISTS_SYMBOL_SET:
-        left_part, right_part = clean_tree_str[:cali_point],\
-            clean_tree_str[cali_point:]
+        left_part, right_part = clean_tree_str[:cali_point], \
+                                clean_tree_str[cali_point:]
         clean_str_with_cali = left_part + cali_info + right_part
     # There was calibration there
     # '>':  >0.05<0.07
@@ -1171,8 +1194,8 @@ def single_calibration(tree_str, name_a, name_b, cali_info):
         # right_part = '>0.3<0.5,(f,g));'
         # re will find '>0.3<0.5' part
         re_find_left_cali = re.compile('^[^,);]+')
-        left_part, right_part = clean_tree_str[:cali_point],\
-            clean_tree_str[cali_point:]
+        left_part, right_part = clean_tree_str[:cali_point], \
+                                clean_tree_str[cali_point:]
         left_cali = re_find_left_cali.findall(right_part)[0]
         print('[Calibration Exists]:          ', left_cali, '  [- Old]')
         print('[Calibration Replaced By]:     ', cali_info, '  [+ New]')
@@ -1190,17 +1213,37 @@ def add_single_branch_label(tree_str, name_a, branch_label):
     '((a ,((b, c #1 ), (d, e))), (f, g));'
     """
     clean_tree_str = get_clean_tree_str(tree_str)
-    insertition_point = get_right_index_of_name(clean_tree_str, name_a)
-    print('\n[Insert]:  ',
-          clean_tree_str[insertition_point-20:insertition_point+20])
-    print('[Insert]:  ', '                 ->||<-                  ')
-    print('[Insert]:  ', '               Insert Here               ')
+    insert_point = get_right_index_of_name(clean_tree_str, name_a)
+
+    tree_len = len(clean_tree_str)
+    print('[Common]:   %s\n' % insert_point)
+    if insert_point < 20 <= tree_len - insert_point:
+        print('[Insert]:   %s%s' % (
+            ' ' * (20 - insert_point),
+            clean_tree_str[:insert_point + 20])
+              )
+    elif insert_point >= 20 > tree_len - insert_point:
+        print('[Insert]:   %s' % (
+            clean_tree_str[
+                insert_point - 20:insert_point + (tree_len - insert_point)])
+              )
+    elif insert_point < 20 and tree_len - insert_point < 20:
+        print('[Insert]:   %s%s' % (
+            ' ' * (20 - insert_point),
+            clean_tree_str[:insert_point + (tree_len - insert_point)])
+              )
+    else:
+        print('[Insert]:   %s' % (
+            clean_tree_str[insert_point - 20:insert_point + 20])
+              )
+    print('[Insert]:                    ->||<-                 ')
+    print('[Insert]:                  Insert Here              ')
 
     # Check is there was something there
     # Nothing there before
-    if clean_tree_str[insertition_point] in NO_LABEL_EXISTS_SYMBOL_SET:
-        left_part, right_part = clean_tree_str[:insertition_point],\
-            clean_tree_str[insertition_point:]
+    if clean_tree_str[insert_point] in NO_LABEL_EXISTS_SYMBOL_SET:
+        left_part, right_part = clean_tree_str[:insert_point], \
+                                clean_tree_str[insert_point:]
         clean_str_with_cali = left_part + ' %s ' % branch_label + right_part
     # There was calibration there
     # '>':  >0.05<0.07
@@ -1212,14 +1255,14 @@ def add_single_branch_label(tree_str, name_a, branch_label):
     # '"':  ">0.05<0.07"
     # '$':  $1
     # ':':  :0.12345
-    elif clean_tree_str[insertition_point] in WITH_LABEL_EXISTS_SYMBOL_SET:
+    elif clean_tree_str[insert_point] in WITH_LABEL_EXISTS_SYMBOL_SET:
         # ((a,((b,c),(d,e)))>0.3<0.5,(f,g));
         # left_part = '((a,((b,c),(d,e)))'
         # right_part = '>0.3<0.5,(f,g));'
         # re will find '>0.3<0.5' part
         re_find_left_cali = re.compile('^[^,);]+')
-        left_part, right_part = clean_tree_str[:insertition_point],\
-            clean_tree_str[insertition_point:]
+        left_part, right_part = (clean_tree_str[:insert_point],
+                                 clean_tree_str[insert_point:])
         left_cali = re_find_left_cali.findall(right_part)[0]
         print('[Label Exists]:          ' + left_cali + '  [- Old]')
         print('[Label Replaced By]:     ' + branch_label + '  [+ New]')
@@ -1229,7 +1272,7 @@ def add_single_branch_label(tree_str, name_a, branch_label):
                                final_right_part)
     else:
         raise ValueError('[Error] [Unknown Symbol]: ' +
-                         clean_tree_str[insertition_point])
+                         clean_tree_str[insert_point])
     return clean_str_with_cali
 
 
@@ -1244,7 +1287,7 @@ def multi_calibration(tree_str, cali_tuple_list):
         if len(each_cali_tuple) == 3:
             name_a, name_b, cali_or_clade_info = each_cali_tuple
             print('\n')
-            print('[%d]:  %s' % (i+1, ', '.join(each_cali_tuple)))
+            print('[%d]:  %s' % (i + 1, ', '.join(each_cali_tuple)))
             print(THIN_BAR)
             print('[Name A]:  ', name_a)
             print('[Name B]:  ', name_b)
@@ -1263,7 +1306,7 @@ def multi_calibration(tree_str, cali_tuple_list):
         elif len(each_cali_tuple) == 2:
             name_a, branch_label = each_cali_tuple
             print('\n')
-            print('[%d]:  %s' % (i+1, ', '.join(each_cali_tuple)))
+            print('[%d]:  %s' % (i + 1, ', '.join(each_cali_tuple)))
             print(THIN_BAR)
             print('[ Name ]:  ', name_a)
             print('[ Info ]:  ', branch_label)
@@ -1297,7 +1340,7 @@ def get_cali_list(raw_cali_content):
             # raise ConfigFileSyntaxError('Invalid calibration line [%d]: %s'
             #                             % (i + 1, line) +
             #                             'Usage:\n\n%s' % error_msg)
-            raise ConfigFileSyntaxError('Invalid line: [%d]: %s' % (i+1, line))
+            raise ConfigFileSyntaxError('Invalid line: [%d]: %s' % (i + 1, line))
         tmp_cali_list.append(elements)
     return tmp_cali_list
 


### PR DESCRIPTION
For a tree like this:

```
((a ,((b, c), (d, e))), (f, g));
```

Given calibration configs:

```
c, b, >0.05<0.07
a, e, >0.1<0.2
c, f, >0.3<0.5
d, e, $1
a, #1
```

Output Newick tree will be:

```
((a#1, ((b, c)>0.05<0.07, (d, e)$1))>0.1<0.2, (f, g))>0.3<0.5;
```

Log will be:

```
[1]:  c, b, >0.05<0.07
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   b
[ Info ]:   >0.05<0.07
[Common]:   10

[Insert]:             ((a,((b,c),(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[2]:  a, e, >0.1<0.2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   a
[Name B]:   e
[ Info ]:   >0.1<0.2
[Common]:   28

[Insert]:   c)>0.05<0.07,(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[3]:  c, f, >0.3<0.5
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   f
[ Info ]:   >0.3<0.5
[Common]:   43

[Insert]:   ,e)))>0.1<0.2,(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[4]:  d, e, $1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   d
[Name B]:   e
[ Info ]:   $1
[Common]:   26

[Insert]:   b,c)>0.05<0.07,(d,e)))>0.1<0.2,(f,g))>0.
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[5]:  a, #1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ Name ]:   a
[ Info ]:   #1
[Common]:   3

[Insert]:                    ((a,((b,c)>0.05<0.07,(d
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Before fixed this bug, insertion point information will not be displayed correctly due to the insert_point<20, or tree_len - insert_point < 20.

Take calibration [1] as example (incorrect display, missing leading blanks):

```
[1]:  c, b, >0.05<0.07
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   b
[ Info ]:   >0.05<0.07
[Common]:   10

[Insert]:   ((a,((b,c),(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
